### PR TITLE
remove the single quote around the 'config' atttribute in the README …

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ The sample output file generated would look like [10-mysql.conf](https://github.
 
 ```nginx
 class { 'collectd::plugins::nginx':
-  'config' => {
+  config => {
     'URL'  => '"http://localhost:80/nginx_status"',
   }
 }


### PR DESCRIPTION
Remove the single quotes around the **config** attribute in the README file. Having the single quotes results in a syntax error as shown below:

```
puppet parser validate monitor.pp

Error: Could not parse for environment production: Syntax error at 'config'; expected '}' at /etc/puppet/manifests/monitor.pp:10
```
