### PR TITLE
Fix out of order update

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,11 +45,6 @@ class collectd (
   Exec { path => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/' ] }
   collectd::check_os_compatibility { $title:
   } ->
-  # run this only on first run to update the sources
-  exec { 'update_system':
-    command => $collectd::params::update_system,
-    unless  => 'which collectd'
-  } ->
   anchor { 'collectd::begin': } ->
     class { '::collectd::get_signalfx_repository': } ->
     class { '::collectd::install': } ->

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -52,13 +52,11 @@ class collectd::params {
 
         case $::operatingsystem {
                 'Ubuntu':{
-                    $update_system = 'apt-get update -y'
                     $signalfx_public_keyid = 'C94EDC608899B00511CCBA4D68EA6297FE128AB0' # public key to repository hosted on launchpad
                     $signalfx_collectd_repo_source  = 'ppa:signalfx/collectd-release'
                     $signalfx_plugin_repo_source    = 'ppa:signalfx/collectd-plugin-release'
                 }
                 'Debian':{
-                    $update_system = 'apt-get update -y'
                     case $::operatingsystemmajrelease {
                         '7': {
                               $signalfx_public_keyid          = '91668001288D1C6D2885D651185894C15AE495F6' # public key to repository hosted on AWS S3
@@ -76,7 +74,6 @@ class collectd::params {
                     }
                 }
                 'RedHat', 'CentOS': {
-                    $update_system = 'yum -y update'
                     $signalfx_collectd_repo_filename = '/etc/yum.repos.d/SignalFx-collectd-RPMs-centos-release.repo' # file created in /etc/yum.repos.d
                     $signalfx_plugin_repo_filename = '/etc/yum.repos.d/SignalFx-collectd_plugin-RPMs-centos-release.repo' # file created in /etc/yum.repos.d
                     case $::operatingsystemmajrelease {
@@ -96,7 +93,6 @@ class collectd::params {
                     }
                 }
                 'Amazon': {
-                        $update_system = 'echo print_dummy_yum_update' # do not update amazon os
                         $signalfx_collectd_repo_filename = '/etc/yum.repos.d/SignalFx-collectd-RPMs-AWS_EC2_Linux-release.repo' # file created in /etc/yum.repos.d
                         $signalfx_plugin_repo_filename = '/etc/yum.repos.d/SignalFx-collectd_plugin-RPMs-AWS_EC2_Linux-release.repo' # file created in /etc/yum.repos.d
                         $signalfx_collectd_repo_source       = 'https://dl.signalfx.com/rpms/SignalFx-rpms/release/SignalFx-collectd-RPMs-AWS_EC2_Linux-release-latest.noarch.rpm'

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -57,13 +57,6 @@ describe 'collectd' do
     end
 
     it {
-      is_expected.to contain_exec('update_system').with({
-        'command' => 'yum -y update',
-        'unless'  => 'which collectd',
-      })
-    }
-
-    it {
       is_expected.to contain_package('SignalFx-collectd-RPMs-centos-7-release').with({
         'ensure' => 'absent',
       })


### PR DESCRIPTION
update_system was bring triggered within init prior to the repo files being
written, this is also not necessary on yum based systems and is all ready
handled within collectd::get_signalfx_repository for apt based systems when
the files are written out.

see https://github.com/signalfx/puppet_collectd/blob/master/manifests/get_signalfx_repository.pp#L21
