### PR TITLE
Update plugins to only install from package when package_required is set

### DIFF
--- a/manifests/plugins/docker.pp
+++ b/manifests/plugins/docker.pp
@@ -3,7 +3,7 @@ class collectd::plugins::docker (
   $filter_metrics = false,
   $filter_metric_rules = {},
   $plugin_template = 'collectd/plugins/docker/10-docker.conf.erb',
-  $package_name = 'collectd-python',
+  $package_name = 'collectd-docker',
   $package_ensure = present,
   $package_required = false
 ) {
@@ -11,50 +11,54 @@ class collectd::plugins::docker (
   Exec { path => [ '/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/' ] }
   include collectd
 
-  if $::osfamily == 'RedHat' {
-    exec { 'install epel-release':
-      command => 'yum install -y epel-release',
-      before  => Package['python-pip']
+  unless $package_required {
+    if $::osfamily == 'RedHat' {
+      exec { 'install epel-release':
+        command => 'yum install -y epel-release',
+        before  => Package['python-pip']
+      }
     }
-  }
 
-  package { 'python-pip':
-    ensure => present,
-  }
+    unless(defined(Package['python-pip'])) {
+      package { 'python-pip':
+        ensure => present,
+      }
+    }
 
-  exec { 'install docker dependencies':
-    command => 'pip install py-dateutil && pip install docker-py>=1.0.0 && pip install jsonpath_rw',
-    require => Package['python-pip']
-  }
+    exec { 'install docker dependencies':
+      command => 'pip install py-dateutil && pip install docker-py>=1.0.0 && pip install jsonpath_rw',
+      require => Package['python-pip']
+    }
 
-  file { ['/usr/share/collectd/docker-collectd-plugin/']:
-    ensure  => directory,
-    owner   => root,
-    group   => 'root',
-    mode    => '0755',
-    before  => File['get dockerplugin.py'],
-    require => Exec['install docker dependencies']
-  }
+    file { ['/usr/share/collectd/docker-collectd-plugin/']:
+      ensure  => directory,
+      owner   => root,
+      group   => 'root',
+      mode    => '0755',
+      before  => File['get dockerplugin.py'],
+      require => Exec['install docker dependencies']
+    }
 
-  file { 'get dockerplugin.py':
-    ensure  => present,
-    replace => 'yes',
-    path    => '/usr/share/collectd/docker-collectd-plugin/dockerplugin.py',
-    owner   => root,
-    group   => 'root',
-    mode    => '0755',
-    content => template('collectd/plugins/docker/dockerplugin.py.erb'),
-    before  => File['get dockerplugin.db'],
-  }
+    file { 'get dockerplugin.py':
+      ensure  => present,
+      replace => 'yes',
+      path    => '/usr/share/collectd/docker-collectd-plugin/dockerplugin.py',
+      owner   => root,
+      group   => 'root',
+      mode    => '0755',
+      content => template('collectd/plugins/docker/dockerplugin.py.erb'),
+      before  => File['get dockerplugin.db'],
+    }
 
-  file { 'get dockerplugin.db':
-    ensure  => present,
-    replace => 'yes',
-    path    => '/usr/share/collectd/docker-collectd-plugin/dockerplugin.db',
-    owner   => root,
-    group   => 'root',
-    mode    => '0755',
-    content => template('collectd/plugins/docker/dockerplugin.db.erb'),
+    file { 'get dockerplugin.db':
+      ensure  => present,
+      replace => 'yes',
+      path    => '/usr/share/collectd/docker-collectd-plugin/dockerplugin.db',
+      owner   => root,
+      group   => 'root',
+      mode    => '0755',
+      content => template('collectd/plugins/docker/dockerplugin.db.erb'),
+    }
   }
 
   collectd::plugins::plugin_common { 'docker':

--- a/manifests/plugins/elasticsearch.pp
+++ b/manifests/plugins/elasticsearch.pp
@@ -3,7 +3,7 @@ class collectd::plugins::elasticsearch (
   $filter_metrics = false,
   $filter_metric_rules = {},
   $plugin_template = 'collectd/plugins/elasticsearch/20-elasticsearch.conf.erb',
-  $package_name = 'collectd-python',
+  $package_name = 'collectd-elasticsearch',
   $package_ensure = present,
   $package_required = false
 ) {
@@ -11,22 +11,24 @@ class collectd::plugins::elasticsearch (
   Exec { path => [ '/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/' ] }
   include collectd
 
-  file { ['/usr/share/collectd/elasticsearch-collectd-plugin/']:
-    ensure => directory,
-    owner  => root,
-    group  => 'root',
-    mode   => '0755',
-    before => File['get elasticsearch_collectd.py'],
-  }
+  unless $package_required {
+    file { ['/usr/share/collectd/elasticsearch-collectd-plugin/']:
+      ensure => directory,
+      owner  => root,
+      group  => 'root',
+      mode   => '0755',
+      before => File['get elasticsearch_collectd.py'],
+    }
 
-  file { 'get elasticsearch_collectd.py':
-    ensure  => present,
-    replace => 'yes',
-    path    => '/usr/share/collectd/elasticsearch-collectd-plugin/elasticsearch_collectd.py',
-    owner   => root,
-    group   => 'root',
-    mode    => '0755',
-    content => template('collectd/plugins/elasticsearch/elasticsearch_collectd.py.erb'),
+    file { 'get elasticsearch_collectd.py':
+      ensure  => present,
+      replace => 'yes',
+      path    => '/usr/share/collectd/elasticsearch-collectd-plugin/elasticsearch_collectd.py',
+      owner   => root,
+      group   => 'root',
+      mode    => '0755',
+      content => template('collectd/plugins/elasticsearch/elasticsearch_collectd.py.erb'),
+    }
   }
 
   collectd::plugins::plugin_common { 'elasticsearch':

--- a/manifests/plugins/iostat.pp
+++ b/manifests/plugins/iostat.pp
@@ -3,7 +3,7 @@ class collectd::plugins::iostat (
   $filter_metrics = false,
   $filter_metric_rules = {},
   $plugin_template = 'collectd/plugins/iostat/10-iostat.conf.erb',
-  $package_name = 'collectd-python',
+  $package_name = 'collectd-iostat',
   $package_ensure = present,
   $package_required = false
 ) {
@@ -11,34 +11,38 @@ class collectd::plugins::iostat (
   Exec { path => [ '/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/' ] }
   include collectd
 
-  if $::osfamily == 'RedHat' {
-    exec { 'install epel-release':
-      command => 'yum install -y epel-release',
-      before  => Package['sysstat']
+  unless $package_required {
+    if $::osfamily == 'RedHat' {
+      exec { 'install epel-release':
+        command => 'yum install -y epel-release',
+        before  => Package['sysstat']
+      }
     }
-  }
 
-  package { 'sysstat':
-    ensure => present,
-  }
+    unless(defined(Package['sysstat'])) {
+      package { 'sysstat':
+        ensure => present,
+      }
+    }
 
-  file { ['/usr/share/collectd/iostat-collectd-plugin/']:
-    ensure => directory,
-    owner  => root,
-    group  => 'root',
-    mode   => '0755',
-    before => File['get collectd_iostat_python.py']
-  }
+    file { ['/usr/share/collectd/iostat-collectd-plugin/']:
+      ensure => directory,
+      owner  => root,
+      group  => 'root',
+      mode   => '0755',
+      before => File['get collectd_iostat_python.py']
+    }
 
-  file { 'get collectd_iostat_python.py':
-    ensure  => present,
-    replace => 'yes',
-    path    => '/usr/share/collectd/iostat-collectd-plugin/collectd_iostat_python.py',
-    owner   => root,
-    group   => 'root',
-    mode    => '0755',
-    content => template('collectd/plugins/iostat/collectd_iostat_python.py.erb'),
-    require => Package['sysstat']
+    file { 'get collectd_iostat_python.py':
+      ensure  => present,
+      replace => 'yes',
+      path    => '/usr/share/collectd/iostat-collectd-plugin/collectd_iostat_python.py',
+      owner   => root,
+      group   => 'root',
+      mode    => '0755',
+      content => template('collectd/plugins/iostat/collectd_iostat_python.py.erb'),
+      require => Package['sysstat']
+    }
   }
 
   collectd::plugins::plugin_common { 'iostat':

--- a/manifests/plugins/java.pp
+++ b/manifests/plugins/java.pp
@@ -7,22 +7,24 @@ class collectd::plugins::java (
   Exec { path => [ '/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/' ] }
   include collectd
 
-  file { ['/usr/share/collectd/java-collectd-plugin/']:
-    ensure => directory,
-    owner  => root,
-    group  => 'root',
-    mode   => '0755',
-    before => File['get signalfx_types_db'],
-  }
+  unless $package_required {
+    file { ['/usr/share/collectd/java-collectd-plugin/']:
+      ensure => directory,
+      owner  => root,
+      group  => 'root',
+      mode   => '0755',
+      before => File['get signalfx_types_db'],
+    }
 
-  file { 'get signalfx_types_db':
-    ensure  => present,
-    replace => 'yes',
-    path    => '/usr/share/collectd/java-collectd-plugin/signalfx_types_db',
-    owner   => root,
-    group   => 'root',
-    mode    => '0755',
-    content => template('collectd/plugins/java/signalfx_types_db.erb'),
+    file { 'get signalfx_types_db':
+      ensure  => present,
+      replace => 'yes',
+      path    => '/usr/share/collectd/java-collectd-plugin/signalfx_types_db',
+      owner   => root,
+      group   => 'root',
+      mode    => '0755',
+      content => template('collectd/plugins/java/signalfx_types_db.erb'),
+    }
   }
 
   collectd::plugins::plugin_common { 'java':

--- a/manifests/plugins/mesos.pp
+++ b/manifests/plugins/mesos.pp
@@ -3,7 +3,7 @@ class collectd::plugins::mesos (
   $filter_metrics = false,
   $filter_metric_rules = {},
   $plugin_template = 'collectd/plugins/mesos/10-mesos-master.conf.erb',
-  $package_name = 'collectd-python',
+  $package_name = 'collectd-mesos',
   $package_ensure = present,
   $package_required = false
 ) {
@@ -11,33 +11,35 @@ class collectd::plugins::mesos (
   Exec { path => [ '/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/' ] }
   include collectd
 
-  file { ['/usr/share/collectd/mesos-collectd-plugin/']:
-    ensure => directory,
-    owner  => root,
-    group  => 'root',
-    mode   => '0755',
-    before => File['get mesos-master.py'],
-  }
+  unless $package_required {
+    file { ['/usr/share/collectd/mesos-collectd-plugin/']:
+      ensure => directory,
+      owner  => root,
+      group  => 'root',
+      mode   => '0755',
+      before => File['get mesos-master.py'],
+    }
 
-  file { 'get mesos-master.py':
-    ensure  => present,
-    replace => 'yes',
-    path    => '/usr/share/collectd/mesos-collectd-plugin/mesos-master.py',
-    owner   => root,
-    group   => 'root',
-    mode    => '0755',
-    content => template('collectd/plugins/mesos/mesos-master.py.erb'),
-    before  => File['get mesos_collectd.py'],
-  }
+    file { 'get mesos-master.py':
+      ensure  => present,
+      replace => 'yes',
+      path    => '/usr/share/collectd/mesos-collectd-plugin/mesos-master.py',
+      owner   => root,
+      group   => 'root',
+      mode    => '0755',
+      content => template('collectd/plugins/mesos/mesos-master.py.erb'),
+      before  => File['get mesos_collectd.py'],
+    }
 
-  file { 'get mesos_collectd.py':
-    ensure  => present,
-    replace => 'yes',
-    path    => '/usr/share/collectd/mesos-collectd-plugin/mesos_collectd.py',
-    owner   => root,
-    group   => 'root',
-    mode    => '0755',
-    content => template('collectd/plugins/mesos/mesos_collectd.py.erb'),
+    file { 'get mesos_collectd.py':
+      ensure  => present,
+      replace => 'yes',
+      path    => '/usr/share/collectd/mesos-collectd-plugin/mesos_collectd.py',
+      owner   => root,
+      group   => 'root',
+      mode    => '0755',
+      content => template('collectd/plugins/mesos/mesos_collectd.py.erb'),
+    }
   }
 
   collectd::plugins::plugin_common { 'mesos':

--- a/manifests/plugins/mongodb.pp
+++ b/manifests/plugins/mongodb.pp
@@ -3,7 +3,7 @@ class collectd::plugins::mongodb (
   $filter_metrics = false,
   $filter_metric_rules = {},
   $plugin_template = 'collectd/plugins/mongodb/10-mongodb.conf.erb',
-  $package_name = 'collectd-python',
+  $package_name = 'collectd-mongodb',
   $package_ensure = present,
   $package_required = false
 ) {
@@ -11,39 +11,43 @@ class collectd::plugins::mongodb (
   Exec { path => [ '/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/' ] }
   include collectd
 
-  if $::osfamily == 'RedHat' {
-    exec { 'install epel-release':
-      command => 'yum install -y epel-release',
-      before  => Package['python-pip']
+  unless $package_required {
+    if $::osfamily == 'RedHat' {
+      exec { 'install epel-release':
+        command => 'yum install -y epel-release',
+        before  => Package['python-pip']
+      }
     }
-  }
 
-  package { 'python-pip':
-    ensure => present,
-  }
+    unless(defined(Package['python-pip'])) {
+      package { 'python-pip':
+        ensure => present,
+      }
+    }
 
-  exec { 'install mongodb dependencies':
-    command => 'pip install pymongo==3.0.3',
-    require => Package['python-pip']
-  }
+    exec { 'install mongodb dependencies':
+      command => 'pip install pymongo==3.0.3',
+      require => Package['python-pip']
+    }
 
-  file { ['/usr/share/collectd/mongodb-collectd-plugin/']:
-    ensure  => directory,
-    owner   => root,
-    group   => 'root',
-    mode    => '0755',
-    before  => File['get mongodb.py'],
-    require => Exec['install mongodb dependencies']
-  }
+    file { ['/usr/share/collectd/mongodb-collectd-plugin/']:
+      ensure  => directory,
+      owner   => root,
+      group   => 'root',
+      mode    => '0755',
+      before  => File['get mongodb.py'],
+      require => Exec['install mongodb dependencies']
+    }
 
-  file { 'get mongodb.py':
-    ensure  => present,
-    replace => 'yes',
-    path    => '/usr/share/collectd/mongodb-collectd-plugin/mongodb.py',
-    owner   => root,
-    group   => 'root',
-    mode    => '0755',
-    content => template('collectd/plugins/mongodb/mongodb.py.erb'),
+    file { 'get mongodb.py':
+      ensure  => present,
+      replace => 'yes',
+      path    => '/usr/share/collectd/mongodb-collectd-plugin/mongodb.py',
+      owner   => root,
+      group   => 'root',
+      mode    => '0755',
+      content => template('collectd/plugins/mongodb/mongodb.py.erb'),
+    }
   }
 
   collectd::plugins::plugin_common { 'mongodb':

--- a/manifests/plugins/rabbitmq.pp
+++ b/manifests/plugins/rabbitmq.pp
@@ -5,7 +5,7 @@ class collectd::plugins::rabbitmq (
   $filter_metrics = false,
   $filter_metric_rules = {},
   $plugin_template = 'collectd/plugins/rabbitmq/rabbitmq.conf.erb',
-  $package_name = 'collectd-python',
+  $package_name = 'collectd-rabbitmq',
   $package_ensure = present,
   $package_required = false
 ) {

--- a/manifests/plugins/redis.pp
+++ b/manifests/plugins/redis.pp
@@ -3,7 +3,7 @@ class collectd::plugins::redis (
   $filter_metrics = false,
   $filter_metric_rules = {},
   $plugin_template = 'collectd/plugins/redis/10-redis_master.conf.erb',
-  $package_name = 'collectd-python',
+  $package_name = 'collectd-redis',
   $package_ensure = present,
   $package_required = false
 ) {
@@ -11,22 +11,24 @@ class collectd::plugins::redis (
   Exec { path => [ '/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/' ] }
   include collectd
 
-  file { ['/usr/share/collectd/redis-collectd-plugin/']:
-    ensure => directory,
-    owner  => root,
-    group  => 'root',
-    mode   => '0755',
-    before => File['get redis_info.py'],
-  }
+  unless $package_required {
+    file { ['/usr/share/collectd/redis-collectd-plugin/']:
+      ensure => directory,
+      owner  => root,
+      group  => 'root',
+      mode   => '0755',
+      before => File['get redis_info.py'],
+    }
 
-  file { 'get redis_info.py':
-    ensure  => present,
-    replace => 'yes',
-    path    => '/usr/share/collectd/redis-collectd-plugin/redis_info.py',
-    owner   => root,
-    group   => 'root',
-    mode    => '0755',
-    content => template('collectd/plugins/redis/redis_info.py.erb'),
+    file { 'get redis_info.py':
+      ensure  => present,
+      replace => 'yes',
+      path    => '/usr/share/collectd/redis-collectd-plugin/redis_info.py',
+      owner   => root,
+      group   => 'root',
+      mode    => '0755',
+      content => template('collectd/plugins/redis/redis_info.py.erb'),
+    }
   }
 
   collectd::plugins::plugin_common { 'redis':

--- a/manifests/plugins/zookeeper.pp
+++ b/manifests/plugins/zookeeper.pp
@@ -3,7 +3,7 @@ class collectd::plugins::zookeeper (
   $filter_metrics = false,
   $filter_metric_rules = {},
   $plugin_template = 'collectd/plugins/zookeeper/20-zookeeper.conf.erb',
-  $package_name = 'collectd-python',
+  $package_name = 'collectd-zookeeper',
   $package_ensure = present,
   $package_required = false
 ) {
@@ -11,22 +11,24 @@ class collectd::plugins::zookeeper (
   Exec { path => [ '/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/' ] }
   include collectd
 
-  file { ['/usr/share/collectd/zookeeper-collectd-plugin/']:
-    ensure => directory,
-    owner  => root,
-    group  => 'root',
-    mode   => '0755',
-    before => File['get zk-collectd.py'],
-  }
+  unless $package_required {
+    file { ['/usr/share/collectd/zookeeper-collectd-plugin/']:
+      ensure => directory,
+      owner  => root,
+      group  => 'root',
+      mode   => '0755',
+      before => File['get zk-collectd.py'],
+    }
 
-  file { 'get zk-collectd.py':
-    ensure  => present,
-    replace => 'yes',
-    path    => '/usr/share/collectd/zookeeper-collectd-plugin/zk-collectd.py',
-    owner   => root,
-    group   => 'root',
-    mode    => '0755',
-    content => template('collectd/plugins/zookeeper/zk-collectd.py.erb'),
+    file { 'get zk-collectd.py':
+      ensure  => present,
+      replace => 'yes',
+      path    => '/usr/share/collectd/zookeeper-collectd-plugin/zk-collectd.py',
+      owner   => root,
+      group   => 'root',
+      mode    => '0755',
+      content => template('collectd/plugins/zookeeper/zk-collectd.py.erb'),
+    }
   }
 
   collectd::plugins::plugin_common { 'zookeeper':


### PR DESCRIPTION
Updates plugins/*.pp to use the package_required param to decide if the
plugin should install the in module plugin version or if it should install
the plugin from a rpm/deb package.
