### PR TITLE
Provide the option to not automatically install remote signalfx repo

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,16 +18,16 @@ class collectd::config inherits collectd {
 
   file { $collectd::params::plugin_config_dir_tree :
       ensure => directory
-  } ->
-  file { $collectd::params::collectd_config_file:
+  }
+  -> file { $collectd::params::collectd_config_file:
       content => template('collectd/collectd.conf.erb'),
       notify  => Service['collectd'],
-  } ->
-  file { $collectd::params::filtering_config_file:
+  }
+  -> file { $collectd::params::filtering_config_file:
       content => template('collectd/filtering.conf.erb'),
       notify  => Service['collectd'],
   }
-  collectd::check_and_create_directory { '/usr/share/collectd/' : } ->
-  collectd::check_and_create_directory { '/usr/share/collectd/java' : } ->
-  collectd::check_and_create_directory { '/usr/share/collectd/python' : }
+  collectd::check_and_create_directory { '/usr/share/collectd/' : }
+  -> collectd::check_and_create_directory { '/usr/share/collectd/java' : }
+  -> collectd::check_and_create_directory { '/usr/share/collectd/python' : }
 }

--- a/manifests/get_signalfx_repository.pp
+++ b/manifests/get_signalfx_repository.pp
@@ -5,35 +5,35 @@ class collectd::get_signalfx_repository inherits collectd {
     if $::osfamily == 'Debian' {
       # Be careful of dependencies here ( -> )
       if $::operatingsystem == 'Ubuntu' {
-          include apt
-          if(!defined(Package['apt-transport-https'])){
-            package {'apt-transport-https': }
-          }
-          apt::key { 'SignalFx public key id for collectd':
-              id     => $collectd::params::signalfx_public_keyid
-          } ->
-          apt::ppa { [$collectd::signalfx_collectd_repo_source, $collectd::signalfx_plugin_repo_source] :
-            package_manage => true,
-            require        => Package['apt-transport-https']
-          }
-        }else {
-          # apt module does not support wheezy and jessie
-          exec { "Add ${collectd::signalfx_collectd_repo_source}, ${collectd::signalfx_plugin_repo_source}":
-              command => "apt-get update &&
-                              apt-get install -y apt-transport-https &&
-                              apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ${collectd::params::signalfx_public_keyid} &&
-                              mkdir -p /etc/apt/sources.list.d/ &&
-                              echo ${collectd::signalfx_collectd_repo_source} > /etc/apt/sources.list.d/signalfx-collectd.list &&
-                              echo ${collectd::signalfx_plugin_repo_source} > /etc/apt/sources.list.d/signalfx-plugin.list &&
-                              apt-get update",
-              unless  => 'test -s /etc/apt/sources.list.d/signalfx-collectd.list && test -s /etc/apt/sources.list.d/signalfx-plugin.list'
-            }
+        include apt
+        if(!defined(Package['apt-transport-https'])){
+          package {'apt-transport-https': }
         }
+        apt::key { 'SignalFx public key id for collectd':
+          id => $collectd::params::signalfx_public_keyid,
+        }
+        -> apt::ppa { [$collectd::signalfx_collectd_repo_source, $collectd::signalfx_plugin_repo_source] :
+          package_manage => true,
+          require        => Package['apt-transport-https']
+        }
+      } else {
+        # apt module does not support wheezy and jessie
+        exec { "Add ${collectd::signalfx_collectd_repo_source}, ${collectd::signalfx_plugin_repo_source}":
+          command => "apt-get update &&
+                          apt-get install -y apt-transport-https &&
+                          apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ${collectd::params::signalfx_public_keyid} &&
+                          mkdir -p /etc/apt/sources.list.d/ &&
+                          echo ${collectd::signalfx_collectd_repo_source} > /etc/apt/sources.list.d/signalfx-collectd.list &&
+                          echo ${collectd::signalfx_plugin_repo_source} > /etc/apt/sources.list.d/signalfx-plugin.list &&
+                          apt-get update",
+          unless  => 'test -s /etc/apt/sources.list.d/signalfx-collectd.list && test -s /etc/apt/sources.list.d/signalfx-plugin.list'
+        }
+      }
     }
     if $::osfamily == 'Redhat' {
       if $collectd::params::old_signalfx_collectd_repo_source != undef {
         package { $collectd::params::old_signalfx_collectd_repo_source:
-          ensure  => absent
+          ensure => absent
         }
       }
       exec { "Add ${collectd::signalfx_collectd_repo_source}, ${collectd::signalfx_plugin_repo_source}":

--- a/manifests/get_signalfx_repository.pp
+++ b/manifests/get_signalfx_repository.pp
@@ -1,6 +1,7 @@
 # Get signalfx repositories on the system
 #
 class collectd::get_signalfx_repository inherits collectd {
+  if $collectd::use_signalfx_remote_repo {
     if $::osfamily == 'Debian' {
       # Be careful of dependencies here ( -> )
       if $::operatingsystem == 'Ubuntu' {
@@ -40,4 +41,5 @@ class collectd::get_signalfx_repository inherits collectd {
         unless  => "test -s ${collectd::params::signalfx_collectd_repo_filename} && test -s ${collectd::params::signalfx_plugin_repo_filename}"
       }
     }
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,15 +56,15 @@ class collectd (
 
   Exec { path => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/' ] }
   collectd::check_os_compatibility { $title:
-  } ->
-  anchor { 'collectd::begin': } ->
-    class { '::collectd::get_signalfx_repository': } ->
-    class { '::collectd::install': } ->
-    class { '::collectd::config': } ->
-    class { '::collectd::plugins::aggregation': } ->
-    class { '::collectd::plugins::write_http': } ->
-    class { '::collectd::plugins::signalfx': } ->
-  anchor { 'collectd::end': }
+  }
+  -> anchor { 'collectd::begin': }
+    -> class { '::collectd::get_signalfx_repository': }
+    -> class { '::collectd::install': }
+    -> class { '::collectd::config': }
+    -> class { '::collectd::plugins::aggregation': }
+    -> class { '::collectd::plugins::write_http': }
+    -> class { '::collectd::plugins::signalfx': }
+  -> anchor { 'collectd::end': }
 
   class { '::collectd::service': }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,7 +49,9 @@ class collectd (
     $signalfx_plugin_cpu_utilization          = $collectd::params::signalfx_plugin_cpu_utilization,
     $signalfx_plugin_cpu_utilization_per_core = $collectd::params::signalfx_plugin_cpu_utilization_per_core,
     $filter_default_metrics                   = $collectd::params::filter_default_metrics,
-    $filter_default_metric_rules              = $collectd::params::filter_default_metric_rules
+    $filter_default_metric_rules              = $collectd::params::filter_default_metric_rules,
+    # Provide or rely on signalfx remote repository
+    $use_signalfx_remote_repo                 = $collectd::use_signalfx_remote_repo,
 )  inherits collectd::params {
 
   Exec { path => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/' ] }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,137 +1,138 @@
 # Contains important parameters, urls
 #
 class collectd::params {
-        $fqdnlookup             = true
-        $hostname               = $::hostname
-        $interval               = 10
-        $timeout                = 2
-        $read_threads           = 5
-        $write_queue_limit_high = 500000
-        $write_queue_limit_low  = 400000
-        $collect_internal_stats = true
-        $log_file               = '/var/log/signalfx-collectd.log'
-        $log_level              = 'info'
-        $loadplugins            = {}
-        $ensure_signalfx_plugin_version = present
-        $dimension_list            = {}
-        $signalfx_api_endpoint     = 'https://ingest.signalfx.com/v1/collectd'
-        $write_http_timeout        = 3000
-        $write_http_buffersize     = 65536
-        $aws_integration           = true
-        $write_http_log_http_error = true
-        $write_http_flush_interval = 10
+  $fqdnlookup             = true
+  $hostname               = $::hostname
+  $interval               = 10
+  $timeout                = 2
+  $read_threads           = 5
+  $write_queue_limit_high = 500000
+  $write_queue_limit_low  = 400000
+  $collect_internal_stats = true
+  $log_file               = '/var/log/signalfx-collectd.log'
+  $log_level              = 'info'
+  $loadplugins            = {}
+  $ensure_signalfx_plugin_version = present
+  $dimension_list            = {}
+  $signalfx_api_endpoint     = 'https://ingest.signalfx.com/v1/collectd'
+  $write_http_timeout        = 3000
+  $write_http_buffersize     = 65536
+  $aws_integration           = true
+  $write_http_log_http_error = true
+  $write_http_flush_interval = 10
 
-        $signalfx_plugin_log_traces               = true
-        $signalfx_plugin_interactive              = false
-        $signalfx_plugin_notifications            = true
-        $signalfx_plugin_notify_level             = 'OKAY'
-        $signalfx_plugin_dpm                      = false
-        $signalfx_plugin_utilization              = true
-        $signalfx_plugin_cpu_utilization          = true
-        $signalfx_plugin_cpu_utilization_per_core = true
-        $filter_default_metrics                   = false
-        $filter_default_metric_rules              = {}
-        $use_default_cpu_plugin                   = true
-        $use_default_cpufreq_plugin               = true
-        $use_default_df_plugin                    = true
-        $use_default_disk_plugin                  = true
-        $use_default_interface_plugin             = true
-        $use_default_load_plugin                  = true
-        $use_default_memory_plugin                = true
-        $use_default_protocols_plugin             = true
-        $use_default_vmem_plugin                  = true
-        $use_default_uptime_plugin                = true
+  $signalfx_plugin_log_traces               = true
+  $signalfx_plugin_interactive              = false
+  $signalfx_plugin_notifications            = true
+  $signalfx_plugin_notify_level             = 'OKAY'
+  $signalfx_plugin_dpm                      = false
+  $signalfx_plugin_utilization              = true
+  $signalfx_plugin_cpu_utilization          = true
+  $signalfx_plugin_cpu_utilization_per_core = true
+  $filter_default_metrics                   = false
+  $filter_default_metric_rules              = {}
+  $use_default_cpu_plugin                   = true
+  $use_default_cpufreq_plugin               = true
+  $use_default_df_plugin                    = true
+  $use_default_disk_plugin                  = true
+  $use_default_interface_plugin             = true
+  $use_default_load_plugin                  = true
+  $use_default_memory_plugin                = true
+  $use_default_protocols_plugin             = true
+  $use_default_vmem_plugin                  = true
+  $use_default_uptime_plugin                = true
 
-        $use_signalfx_remote_repo = true
-        # Do not change these values, they are here for code reuse
-        if $::osfamily == 'Debian' {
-          $plugin_config_dir_tree      = ['/etc/collectd/', '/etc/collectd/managed_config', '/etc/collectd/filtering_config']
-          $include_plugin_dirs         = ['/etc/collectd/managed_config', '/etc/collectd/filtering_config']
-          $plugin_config_dir           = '/etc/collectd/managed_config'
-          $collectd_config_file        = '/etc/collectd/collectd.conf'
-          $filtering_config_file       = '/etc/collectd/filtering_config/filtering.conf'
-          $mysql_socket_file           = '/var/lib/mysqld/mysqld.sock'
-        }
-        elsif $::osfamily == 'Redhat' {
-          $plugin_config_dir_tree     = ['/etc/collectd.d/', '/etc/collectd.d/managed_config', '/etc/collectd.d/filtering_config']
-          $include_plugin_dirs        = ['/etc/collectd.d/managed_config', '/etc/collectd.d/filtering_config']
-          $plugin_config_dir          = '/etc/collectd.d/managed_config'
-          $collectd_config_file       = '/etc/collectd.conf'
-          $filtering_config_file      = '/etc/collectd.d/filtering_config/filtering.conf'
-          $mysql_socket_file          = '/var/lib/mysql/mysql.sock'
-        }
+  $use_signalfx_remote_repo = true
 
-        case $::operatingsystem {
-                'Ubuntu':{
-                    $signalfx_public_keyid = 'C94EDC608899B00511CCBA4D68EA6297FE128AB0' # public key to repository hosted on launchpad
-                    $signalfx_collectd_repo_source  = 'ppa:signalfx/collectd-release'
-                    $signalfx_plugin_repo_source    = 'ppa:signalfx/collectd-plugin-release'
-                }
-                'Debian':{
-                    case $::operatingsystemmajrelease {
-                        '7': {
-                              $signalfx_public_keyid          = '91668001288D1C6D2885D651185894C15AE495F6' # public key to repository hosted on AWS S3
-                              $signalfx_collectd_repo_source  = 'deb https://dl.signalfx.com/debs/collectd/wheezy/release /'
-                              $signalfx_plugin_repo_source    = 'deb https://dl.signalfx.com/debs/signalfx-collectd-plugin/wheezy/release /'
-                        }
-                        '8': {
-                              $signalfx_public_keyid          = '91668001288D1C6D2885D651185894C15AE495F6' # public key to repository hosted on AWS S3
-                              $signalfx_collectd_repo_source  = 'deb https://dl.signalfx.com/debs/collectd/jessie/release /'
-                              $signalfx_plugin_repo_source    = 'deb https://dl.signalfx.com/debs/signalfx-collectd-plugin/jessie/release /'
-                        }
-                        default: {
-                                fail("Your Debian OS major release : ${::operatingsystemmajrelease} is not supported.")
-                        }
-                    }
-                }
-                'RedHat', 'CentOS': {
-                    $signalfx_collectd_repo_filename = '/etc/yum.repos.d/SignalFx-collectd-RPMs-centos-release.repo' # file created in /etc/yum.repos.d
-                    $signalfx_plugin_repo_filename = '/etc/yum.repos.d/SignalFx-collectd_plugin-RPMs-centos-release.repo' # file created in /etc/yum.repos.d
-                    case $::operatingsystemmajrelease {
-                        '7': {
-                            $old_signalfx_collectd_repo_source   = 'SignalFx-collectd-RPMs-centos-7-release'
-                            $signalfx_collectd_repo_source       = 'https://dl.signalfx.com/rpms/SignalFx-rpms/release/SignalFx-collectd-RPMs-centos-release-latest.noarch.rpm'
-                            $signalfx_plugin_repo_source         = 'https://dl.signalfx.com/rpms/SignalFx-rpms/release/SignalFx-collectd_plugin-RPMs-centos-release-latest.noarch.rpm'
-                        }
-                        '6': {
-                            $old_signalfx_collectd_repo_source   = 'SignalFx-collectd-RPMs-centos-6-release'
-                            $signalfx_collectd_repo_source       = 'https://dl.signalfx.com/rpms/SignalFx-rpms/release/SignalFx-collectd-RPMs-centos-release-latest.noarch.rpm'
-                            $signalfx_plugin_repo_source         = 'https://dl.signalfx.com/rpms/SignalFx-rpms/release/SignalFx-collectd_plugin-RPMs-centos-release-latest.noarch.rpm'
-                        }
-                        default: {
-                            fail("Your OS major release : ${::operatingsystemmajrelease} is not supported.")
-                        }
-                    }
-                }
-                'Amazon': {
-                        $signalfx_collectd_repo_filename = '/etc/yum.repos.d/SignalFx-collectd-RPMs-AWS_EC2_Linux-release.repo' # file created in /etc/yum.repos.d
-                        $signalfx_plugin_repo_filename = '/etc/yum.repos.d/SignalFx-collectd_plugin-RPMs-AWS_EC2_Linux-release.repo' # file created in /etc/yum.repos.d
-                        $signalfx_collectd_repo_source       = 'https://dl.signalfx.com/rpms/SignalFx-rpms/release/SignalFx-collectd-RPMs-AWS_EC2_Linux-release-latest.noarch.rpm'
-                        $signalfx_plugin_repo_source         = 'https://dl.signalfx.com/rpms/SignalFx-rpms/release/SignalFx-collectd_plugin-RPMs-AWS_EC2_Linux-release-latest.noarch.rpm'
-                        case $::operatingsystemrelease {
-                            '2016.03': {
-                                # No old_signalfx_collectd_repo_source on 2016.03
-                            }
-                            '2015.09': {
-                                $old_signalfx_collectd_repo_source   = 'SignalFx-collectd-RPMs-AWS_EC2_Linux_2015_09-release'
-                            }
-                            '2015.03': {
-                                $old_signalfx_collectd_repo_source   = 'SignalFx-collectd-RPMs-AWS_EC2_Linux_2015_03-release'
-                            }
-                            '2014.09': {
-                                $old_signalfx_collectd_repo_source   = 'SignalFx-collectd-RPMs-AWS_EC2_Linux_2014_09-release'
-                            }
-                            default: {
-                              if versioncmp($::facterversion, '1.6.18') <= 0 and $::operatingsystem == 'Amazon' {
-                                fail("Your facter version ${::facterversion} is not supported by our module. More info can be found at https://support.signalfx.com/hc/en-us/articles/205675369")
-                              }else {
-                                  fail("Your operating system release : ${::operatingsystemrelease} is not supported.")
-                              }
-                            }
-                        }
-                }
-                default: {
-                        fail("Your operating system : ${::operatingsystem} is not supported.")
-                }
+  # Do not change these values, they are here for plugin_config_dire reuse
+  if $::osfamily == 'Debian' {
+    $plugin_config_dir_tree      = ['/etc/collectd/', '/etc/collectd/managed_config', '/etc/collectd/filtering_config']
+    $include_plugin_dirs         = ['/etc/collectd/managed_config', '/etc/collectd/filtering_config']
+    $plugin_config_dir           = '/etc/collectd/managed_config'
+    $collectd_config_file        = '/etc/collectd/collectd.conf'
+    $filtering_config_file       = '/etc/collectd/filtering_config/filtering.conf'
+    $mysql_socket_file           = '/var/lib/mysqld/mysqld.sock'
+  }
+  elsif $::osfamily == 'Redhat' {
+    $plugin_config_dir_tree     = ['/etc/collectd.d/', '/etc/collectd.d/managed_config', '/etc/collectd.d/filtering_config']
+    $include_plugin_dirs        = ['/etc/collectd.d/managed_config', '/etc/collectd.d/filtering_config']
+    $plugin_config_dir          = '/etc/collectd.d/managed_config'
+    $collectd_config_file       = '/etc/collectd.conf'
+    $filtering_config_file      = '/etc/collectd.d/filtering_config/filtering.conf'
+    $mysql_socket_file          = '/var/lib/mysql/mysql.sock'
+  }
+
+  case $::operatingsystem {
+    'Ubuntu':{
+      $signalfx_public_keyid = 'C94EDC608899B00511CCBA4D68EA6297FE128AB0' # public key to repository hosted on launchpad
+      $signalfx_collectd_repo_source  = 'ppa:signalfx/collectd-release'
+      $signalfx_plugin_repo_source    = 'ppa:signalfx/collectd-plugin-release'
+    }
+    'Debian':{
+      case $::operatingsystemmajrelease {
+        '7': {
+          $signalfx_public_keyid          = '91668001288D1C6D2885D651185894C15AE495F6' # public key to repository hosted on AWS S3
+          $signalfx_collectd_repo_source  = 'deb https://dl.signalfx.com/debs/collectd/wheezy/release /'
+          $signalfx_plugin_repo_source    = 'deb https://dl.signalfx.com/debs/signalfx-collectd-plugin/wheezy/release /'
         }
+        '8': {
+          $signalfx_public_keyid          = '91668001288D1C6D2885D651185894C15AE495F6' # public key to repository hosted on AWS S3
+          $signalfx_collectd_repo_source  = 'deb https://dl.signalfx.com/debs/collectd/jessie/release /'
+          $signalfx_plugin_repo_source    = 'deb https://dl.signalfx.com/debs/signalfx-collectd-plugin/jessie/release /'
+        }
+        default: {
+          fail("Your Debian OS major release : ${::operatingsystemmajrelease} is not supported.")
+        }
+      }
+    }
+    'RedHat', 'CentOS': {
+      $signalfx_collectd_repo_filename = '/etc/yum.repos.d/SignalFx-collectd-RPMs-centos-release.repo' # file created in /etc/yum.repos.d
+      $signalfx_plugin_repo_filename = '/etc/yum.repos.d/SignalFx-collectd_plugin-RPMs-centos-release.repo' # file created in /etc/yum.repos.d
+      case $::operatingsystemmajrelease {
+        '7': {
+          $old_signalfx_collectd_repo_source   = 'SignalFx-collectd-RPMs-centos-7-release'
+          $signalfx_collectd_repo_source       = 'https://dl.signalfx.com/rpms/SignalFx-rpms/release/SignalFx-collectd-RPMs-centos-release-latest.noarch.rpm'
+          $signalfx_plugin_repo_source         = 'https://dl.signalfx.com/rpms/SignalFx-rpms/release/SignalFx-collectd_plugin-RPMs-centos-release-latest.noarch.rpm'
+        }
+        '6': {
+          $old_signalfx_collectd_repo_source   = 'SignalFx-collectd-RPMs-centos-6-release'
+          $signalfx_collectd_repo_source       = 'https://dl.signalfx.com/rpms/SignalFx-rpms/release/SignalFx-collectd-RPMs-centos-release-latest.noarch.rpm'
+          $signalfx_plugin_repo_source         = 'https://dl.signalfx.com/rpms/SignalFx-rpms/release/SignalFx-collectd_plugin-RPMs-centos-release-latest.noarch.rpm'
+        }
+        default: {
+          fail("Your OS major release : ${::operatingsystemmajrelease} is not supported.")
+        }
+      }
+    }
+    'Amazon': {
+      $signalfx_collectd_repo_filename = '/etc/yum.repos.d/SignalFx-collectd-RPMs-AWS_EC2_Linux-release.repo' # file created in /etc/yum.repos.d
+      $signalfx_plugin_repo_filename = '/etc/yum.repos.d/SignalFx-collectd_plugin-RPMs-AWS_EC2_Linux-release.repo' # file created in /etc/yum.repos.d
+      $signalfx_collectd_repo_source       = 'https://dl.signalfx.com/rpms/SignalFx-rpms/release/SignalFx-collectd-RPMs-AWS_EC2_Linux-release-latest.noarch.rpm'
+      $signalfx_plugin_repo_source         = 'https://dl.signalfx.com/rpms/SignalFx-rpms/release/SignalFx-collectd_plugin-RPMs-AWS_EC2_Linux-release-latest.noarch.rpm'
+      case $::operatingsystemrelease {
+        '2016.03': {
+          # No old_signalfx_collectd_repo_source on 2016.03
+        }
+        '2015.09': {
+          $old_signalfx_collectd_repo_source   = 'SignalFx-collectd-RPMs-AWS_EC2_Linux_2015_09-release'
+        }
+        '2015.03': {
+          $old_signalfx_collectd_repo_source   = 'SignalFx-collectd-RPMs-AWS_EC2_Linux_2015_03-release'
+        }
+        '2014.09': {
+          $old_signalfx_collectd_repo_source   = 'SignalFx-collectd-RPMs-AWS_EC2_Linux_2014_09-release'
+        }
+        default: {
+          if versioncmp($::facterversion, '1.6.18') <= 0 and $::operatingsystem == 'Amazon' {
+            fail("Your facter version ${::facterversion} is not supported by our module. More info can be found at https://support.signalfx.com/hc/en-us/articles/205675369")
+          } else {
+            fail("Your operating system release : ${::operatingsystemrelease} is not supported.")
+          }
+        }
+      }
+    }
+    default: {
+      fail("Your operating system : ${::operatingsystem} is not supported.")
+    }
+  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -42,6 +42,7 @@ class collectd::params {
         $use_default_vmem_plugin                  = true
         $use_default_uptime_plugin                = true
 
+        $use_signalfx_remote_repo = true
         # Do not change these values, they are here for code reuse
         if $::osfamily == 'Debian' {
           $plugin_config_dir_tree      = ['/etc/collectd/', '/etc/collectd/managed_config', '/etc/collectd/filtering_config']

--- a/manifests/plugins/rabbitmq.pp
+++ b/manifests/plugins/rabbitmq.pp
@@ -16,8 +16,8 @@ class collectd::plugins::rabbitmq (
   collectd::get_from_github { $title:
     localfolder => '/opt/collectd-rabbitmq',
     source      => 'https://github.com/signalfx/collectd-rabbitmq'
-  } ->
-  collectd::plugins::plugin_common { 'rabbitmq':
+  }
+  -> collectd::plugins::plugin_common { 'rabbitmq':
     package_name     => $package_name,
     package_ensure   => $package_ensure,
     package_required => $package_required,


### PR DESCRIPTION
We pull in our repository internally, as to not be dependent on internet
repository