### PR TITLE
Fix plugin modules configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 Release 0.1.11
+  * Fix for plugin modules configuration
   * Add ability to disable individual default plugins
   * Add df plugin as custom configurable
   * Add disk plugin as custom configurable

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -9,7 +9,7 @@ class collectd::config inherits collectd {
 
   if $::operatingsystem == 'CentOS' and $::operatingsystemmajrelease == '7' {
     $log_file = 'stdout'
-  }else {
+  } else {
     file { $collectd::log_file:
       ensure => present,
       before => File[$collectd::params::collectd_config_file]
@@ -18,16 +18,16 @@ class collectd::config inherits collectd {
 
   file { $collectd::params::plugin_config_dir_tree :
       ensure => directory
-  } ->
-  file { $collectd::params::collectd_config_file:
+  }
+  -> file { $collectd::params::collectd_config_file:
       content => template('collectd/collectd.conf.erb'),
       notify  => Service['collectd'],
-  } ->
-  file { $collectd::params::filtering_config_file:
+  }
+  -> file { $collectd::params::filtering_config_file:
       content => template('collectd/filtering.conf.erb'),
       notify  => Service['collectd'],
   }
-  collectd::check_and_create_directory { '/usr/share/collectd/' : } ->
-  collectd::check_and_create_directory { '/usr/share/collectd/java' : } ->
-  collectd::check_and_create_directory { '/usr/share/collectd/python' : }
+  collectd::check_and_create_directory { '/usr/share/collectd/' : }
+  -> collectd::check_and_create_directory { '/usr/share/collectd/java' : }
+  -> collectd::check_and_create_directory { '/usr/share/collectd/python' : }
 }

--- a/manifests/get_signalfx_repository.pp
+++ b/manifests/get_signalfx_repository.pp
@@ -10,12 +10,12 @@ class collectd::get_signalfx_repository inherits collectd {
           }
           apt::key { 'SignalFx public key id for collectd':
               id     => $collectd::params::signalfx_public_keyid
-          } ->
-          apt::ppa { [$collectd::signalfx_collectd_repo_source, $collectd::signalfx_plugin_repo_source] :
+          }
+          -> apt::ppa { [$collectd::signalfx_collectd_repo_source, $collectd::signalfx_plugin_repo_source] :
             package_manage => true,
             require        => Package['apt-transport-https']
           }
-        }else {
+        } else {
           # apt module does not support wheezy and jessie
           exec { "Add ${collectd::signalfx_collectd_repo_source}, ${collectd::signalfx_plugin_repo_source}":
               command => "apt-get update &&

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,15 +54,15 @@ class collectd (
 
   Exec { path => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/' ] }
   collectd::check_os_compatibility { $title:
-  } ->
-  anchor { 'collectd::begin': } ->
-    class { '::collectd::get_signalfx_repository': } ->
-    class { '::collectd::install': } ->
-    class { '::collectd::config': } ->
-    class { '::collectd::plugins::aggregation': } ->
-    class { '::collectd::plugins::write_http': } ->
-    class { '::collectd::plugins::signalfx': } ->
-  anchor { 'collectd::end': }
+  }
+  -> anchor { 'collectd::begin': }
+  -> class { '::collectd::get_signalfx_repository': }
+  -> class { '::collectd::install': }
+  -> class { '::collectd::config': }
+  -> class { '::collectd::plugins::aggregation': }
+  -> class { '::collectd::plugins::write_http': }
+  -> class { '::collectd::plugins::signalfx': }
+  -> anchor { 'collectd::end': }
 
   class { '::collectd::service': }
 }

--- a/manifests/plugins/apache.pp
+++ b/manifests/plugins/apache.pp
@@ -12,10 +12,13 @@ class collectd::plugins::apache (
   include collectd
 
   collectd::plugins::plugin_common { 'apache':
-    package_name     => $package_name,
-    package_ensure   => $package_ensure,
-    package_required => $package_required,
-    plugin_file_name => '10-apache.conf',
-    plugin_template  => $plugin_template,
+    modules             => $modules,
+    filter_metrics      => $filter_metrics,
+    filter_metric_rules => $filter_metric_rules,
+    package_name        => $package_name,
+    package_ensure      => $package_ensure,
+    package_required    => $package_required,
+    plugin_file_name    => '10-apache.conf',
+    plugin_template     => $plugin_template,
   }
 }

--- a/manifests/plugins/cassandra.pp
+++ b/manifests/plugins/cassandra.pp
@@ -11,6 +11,7 @@ class collectd::plugins::cassandra (
   include collectd::plugins::java
 
   collectd::plugins::plugin_common { 'cassandra':
+    modules          => $modules,
     package_name     => $package_name,
     package_ensure   => $package_ensure,
     package_required => $package_required,

--- a/manifests/plugins/df.pp
+++ b/manifests/plugins/df.pp
@@ -12,10 +12,13 @@ class collectd::plugins::df (
   include collectd
 
   collectd::plugins::plugin_common { 'df':
-    package_name     => $package_name,
-    package_ensure   => $package_ensure,
-    package_required => $package_required,
-    plugin_file_name => '10-df.conf',
-    plugin_template  => $plugin_template,
+    modules             => $modules,
+    filter_metrics      => $filter_metrics,
+    filter_metric_rules => $filter_metric_rules,
+    package_name        => $package_name,
+    package_ensure      => $package_ensure,
+    package_required    => $package_required,
+    plugin_file_name    => '10-df.conf',
+    plugin_template     => $plugin_template,
   }
 }

--- a/manifests/plugins/disk.pp
+++ b/manifests/plugins/disk.pp
@@ -12,10 +12,13 @@ class collectd::plugins::disk (
   include collectd
 
   collectd::plugins::plugin_common { 'disk':
-    package_name     => $package_name,
-    package_ensure   => $package_ensure,
-    package_required => $package_required,
-    plugin_file_name => '10-disk.conf',
-    plugin_template  => $plugin_template,
+    modules             => $modules,
+    filter_metrics      => $filter_metrics,
+    filter_metric_rules => $filter_metric_rules,
+    package_name        => $package_name,
+    package_ensure      => $package_ensure,
+    package_required    => $package_required,
+    plugin_file_name    => '10-disk.conf',
+    plugin_template     => $plugin_template,
   }
 }

--- a/manifests/plugins/docker.pp
+++ b/manifests/plugins/docker.pp
@@ -58,10 +58,13 @@ class collectd::plugins::docker (
   }
 
   collectd::plugins::plugin_common { 'docker':
-    package_name     => $package_name,
-    package_ensure   => $package_ensure,
-    package_required => $package_required,
-    plugin_file_name => '10-docker.conf',
-    plugin_template  => $plugin_template,
+    modules             => $modules,
+    filter_metrics      => $filter_metrics,
+    filter_metric_rules => $filter_metric_rules,
+    package_name        => $package_name,
+    package_ensure      => $package_ensure,
+    package_required    => $package_required,
+    plugin_file_name    => '10-docker.conf',
+    plugin_template     => $plugin_template,
   }
 }

--- a/manifests/plugins/elasticsearch.pp
+++ b/manifests/plugins/elasticsearch.pp
@@ -30,10 +30,13 @@ class collectd::plugins::elasticsearch (
   }
 
   collectd::plugins::plugin_common { 'elasticsearch':
-    package_name     => $package_name,
-    package_ensure   => $package_ensure,
-    package_required => $package_required,
-    plugin_file_name => '20-elasticsearch.conf',
-    plugin_template  => $plugin_template,
+    modules             => $modules,
+    filter_metrics      => $filter_metrics,
+    filter_metric_rules => $filter_metric_rules,
+    package_name        => $package_name,
+    package_ensure      => $package_ensure,
+    package_required    => $package_required,
+    plugin_file_name    => '20-elasticsearch.conf',
+    plugin_template     => $plugin_template,
   }
 }

--- a/manifests/plugins/iostat.pp
+++ b/manifests/plugins/iostat.pp
@@ -42,10 +42,13 @@ class collectd::plugins::iostat (
   }
 
   collectd::plugins::plugin_common { 'iostat':
-    package_name     => $package_name,
-    package_ensure   => $package_ensure,
-    package_required => $package_required,
-    plugin_file_name => '10-iostat.conf',
-    plugin_template  => $plugin_template,
+    modules             => $modules,
+    filter_metrics      => $filter_metrics,
+    filter_metric_rules => $filter_metric_rules,
+    package_name        => $package_name,
+    package_ensure      => $package_ensure,
+    package_required    => $package_required,
+    plugin_file_name    => '10-iostat.conf',
+    plugin_template     => $plugin_template,
   }
 }

--- a/manifests/plugins/kafka.pp
+++ b/manifests/plugins/kafka.pp
@@ -11,6 +11,7 @@ class collectd::plugins::kafka (
   include collectd::plugins::java
 
   collectd::plugins::plugin_common { 'kafka':
+    modules          => $modules,
     package_name     => $package_name,
     package_ensure   => $package_ensure,
     package_required => $package_required,

--- a/manifests/plugins/memcached.pp
+++ b/manifests/plugins/memcached.pp
@@ -12,11 +12,13 @@ class collectd::plugins::memcached (
   include collectd
 
   collectd::plugins::plugin_common { 'memcached':
-    package_name     => $package_name,
-    package_ensure   => $package_ensure,
-    package_required => $package_required,
-    plugin_file_name => '10-memcached.conf',
-    plugin_template  => $plugin_template,
+    modules             => $modules,
+    filter_metrics      => $filter_metrics,
+    filter_metric_rules => $filter_metric_rules,
+    package_name        => $package_name,
+    package_ensure      => $package_ensure,
+    package_required    => $package_required,
+    plugin_file_name    => '10-memcached.conf',
+    plugin_template     => $plugin_template,
   }
 }
-

--- a/manifests/plugins/mesos.pp
+++ b/manifests/plugins/mesos.pp
@@ -41,10 +41,13 @@ class collectd::plugins::mesos (
   }
 
   collectd::plugins::plugin_common { 'mesos':
-    package_name     => $package_name,
-    package_ensure   => $package_ensure,
-    package_required => $package_required,
-    plugin_file_name => '10-mesos-master.conf',
-    plugin_template  => $plugin_template,
+    modules             => $modules,
+    filter_metrics      => $filter_metrics,
+    filter_metric_rules => $filter_metric_rules,
+    package_name        => $package_name,
+    package_ensure      => $package_ensure,
+    package_required    => $package_required,
+    plugin_file_name    => '10-mesos-master.conf',
+    plugin_template     => $plugin_template,
   }
 }

--- a/manifests/plugins/mongodb.pp
+++ b/manifests/plugins/mongodb.pp
@@ -47,10 +47,13 @@ class collectd::plugins::mongodb (
   }
 
   collectd::plugins::plugin_common { 'mongodb':
-    package_name     => $package_name,
-    package_ensure   => $package_ensure,
-    package_required => $package_required,
-    plugin_file_name => '10-mongodb.conf',
-    plugin_template  => $plugin_template,
+    modules             => $modules,
+    filter_metrics      => $filter_metrics,
+    filter_metric_rules => $filter_metric_rules,
+    package_name        => $package_name,
+    package_ensure      => $package_ensure,
+    package_required    => $package_required,
+    plugin_file_name    => '10-mongodb.conf',
+    plugin_template     => $plugin_template,
   }
 }

--- a/manifests/plugins/mysql.pp
+++ b/manifests/plugins/mysql.pp
@@ -12,10 +12,13 @@ class collectd::plugins::mysql (
   include collectd
 
   collectd::plugins::plugin_common { 'mysql':
-    package_name     => $package_name,
-    package_ensure   => $package_ensure,
-    package_required => $package_required,
-    plugin_file_name => '10-mysql.conf',
-    plugin_template  => $plugin_template,
+    modules             => $modules,
+    filter_metrics      => $filter_metrics,
+    filter_metric_rules => $filter_metric_rules,
+    package_name        => $package_name,
+    package_ensure      => $package_ensure,
+    package_required    => $package_required,
+    plugin_file_name    => '10-mysql.conf',
+    plugin_template     => $plugin_template,
   }
 }

--- a/manifests/plugins/nginx.pp
+++ b/manifests/plugins/nginx.pp
@@ -12,10 +12,13 @@ class collectd::plugins::nginx (
   include collectd
 
   collectd::plugins::plugin_common { 'nginx':
-    package_name     => $package_name,
-    package_ensure   => $package_ensure,
-    package_required => $package_required,
-    plugin_file_name => '10-nginx.conf',
-    plugin_template  => $plugin_template,
+    modules             => $modules,
+    filter_metrics      => $filter_metrics,
+    filter_metric_rules => $filter_metric_rules,
+    package_name        => $package_name,
+    package_ensure      => $package_ensure,
+    package_required    => $package_required,
+    plugin_file_name    => '10-nginx.conf',
+    plugin_template     => $plugin_template,
   }
 }

--- a/manifests/plugins/plugin_common.pp
+++ b/manifests/plugins/plugin_common.pp
@@ -3,6 +3,9 @@
 define collectd::plugins::plugin_common (
   $plugin_file_name,
   $plugin_template,
+  $modules = undef,
+  $filter_metrics = false,
+  $filter_metric_rules = {},
   $package_name = 'UNSET',
   $package_ensure = present,
   $package_required = false,

--- a/manifests/plugins/postgresql.pp
+++ b/manifests/plugins/postgresql.pp
@@ -12,10 +12,13 @@ class collectd::plugins::postgresql (
   include collectd
 
   collectd::plugins::plugin_common { 'postgresql':
-    package_name     => $package_name,
-    package_ensure   => $package_ensure,
-    package_required => $package_required,
-    plugin_file_name => '10-postgresql.conf',
-    plugin_template  => $plugin_template,
+    modules             => $modules,
+    filter_metrics      => $filter_metrics,
+    filter_metric_rules => $filter_metric_rules,
+    package_name        => $package_name,
+    package_ensure      => $package_ensure,
+    package_required    => $package_required,
+    plugin_file_name    => '10-postgresql.conf',
+    plugin_template     => $plugin_template,
   }
 }

--- a/manifests/plugins/rabbitmq.pp
+++ b/manifests/plugins/rabbitmq.pp
@@ -16,12 +16,15 @@ class collectd::plugins::rabbitmq (
   collectd::get_from_github { $title:
     localfolder => '/opt/collectd-rabbitmq',
     source      => 'https://github.com/signalfx/collectd-rabbitmq'
-  } ->
-  collectd::plugins::plugin_common { 'rabbitmq':
-    package_name     => $package_name,
-    package_ensure   => $package_ensure,
-    package_required => $package_required,
-    plugin_file_name => '10-rabbitmq.conf',
-    plugin_template  => $plugin_template,
+  }
+  -> collectd::plugins::plugin_common { 'rabbitmq':
+    modules             => $modules,
+    filter_metrics      => $filter_metrics,
+    filter_metric_rules => $filter_metric_rules,
+    package_name        => $package_name,
+    package_ensure      => $package_ensure,
+    package_required    => $package_required,
+    plugin_file_name    => '10-rabbitmq.conf',
+    plugin_template     => $plugin_template,
   }
 }

--- a/manifests/plugins/redis.pp
+++ b/manifests/plugins/redis.pp
@@ -30,10 +30,13 @@ class collectd::plugins::redis (
   }
 
   collectd::plugins::plugin_common { 'redis':
-    package_name     => $package_name,
-    package_ensure   => $package_ensure,
-    package_required => $package_required,
-    plugin_file_name => '10-redis_master.conf',
-    plugin_template  => $plugin_template,
+    modules             => $modules,
+    filter_metrics      => $filter_metrics,
+    filter_metric_rules => $filter_metric_rules,
+    package_name        => $package_name,
+    package_ensure      => $package_ensure,
+    package_required    => $package_required,
+    plugin_file_name    => '10-redis_master.conf',
+    plugin_template     => $plugin_template,
   }
 }

--- a/manifests/plugins/varnish.pp
+++ b/manifests/plugins/varnish.pp
@@ -12,10 +12,13 @@ class collectd::plugins::varnish (
   include collectd
 
   collectd::plugins::plugin_common { 'varnish':
-    package_name     => $package_name,
-    package_ensure   => $package_ensure,
-    package_required => $package_required,
-    plugin_file_name => '10-varnish.conf',
-    plugin_template  => $plugin_template,
+    modules             => $modules,
+    filter_metrics      => $filter_metrics,
+    filter_metric_rules => $filter_metric_rules,
+    package_name        => $package_name,
+    package_ensure      => $package_ensure,
+    package_required    => $package_required,
+    plugin_file_name    => '10-varnish.conf',
+    plugin_template     => $plugin_template,
   }
 }

--- a/manifests/plugins/vmstat.pp
+++ b/manifests/plugins/vmstat.pp
@@ -42,10 +42,13 @@ class collectd::plugins::vmstat (
   }
 
   collectd::plugins::plugin_common { 'vmstat':
-    package_name     => $package_name,
-    package_ensure   => $package_ensure,
-    package_required => $package_required,
-    plugin_file_name => '10-vmstat.conf',
-    plugin_template  => $plugin_template,
+    modules             => $modules,
+    filter_metrics      => $filter_metrics,
+    filter_metric_rules => $filter_metric_rules,
+    package_name        => $package_name,
+    package_ensure      => $package_ensure,
+    package_required    => $package_required,
+    plugin_file_name    => '10-vmstat.conf',
+    plugin_template     => $plugin_template,
   }
 }

--- a/manifests/plugins/zookeeper.pp
+++ b/manifests/plugins/zookeeper.pp
@@ -30,10 +30,13 @@ class collectd::plugins::zookeeper (
   }
 
   collectd::plugins::plugin_common { 'zookeeper':
-    package_name     => $package_name,
-    package_ensure   => $package_ensure,
-    package_required => $package_required,
-    plugin_file_name => '20-zookeeper.conf',
-    plugin_template  => $plugin_template,
+    modules             => $modules,
+    filter_metrics      => $filter_metrics,
+    filter_metric_rules => $filter_metric_rules,
+    package_name        => $package_name,
+    package_ensure      => $package_ensure,
+    package_required    => $package_required,
+    plugin_file_name    => '20-zookeeper.conf',
+    plugin_template     => $plugin_template,
   }
 }


### PR DESCRIPTION
Fixes issues where plugin $modules, $filter_metrics, and $filter_metric_rules
are not getting passed from each plugin to collectd::plugins::plugin_common.

This patch closes #57, closes #49