### PR TITLE
Update minimum version of puppetlabs/apt to 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Release 0.1.18
+  * Support for Ubuntu 18.04 and Amazon Linux 2017.12 and 2018.03
+  * Update minimum version of puppetlabs/apt to 2.3.0
+
 Release 0.1.17
   * Add HAProxy plugin
 

--- a/metadata.json
+++ b/metadata.json
@@ -68,7 +68,7 @@
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.5.0"},
     {"name":"puppetlabs/concat","version_requirement":">= 1.0.4"},
-    {"name":"puppetlabs/apt","version_requirement":">= 2.2.2"},
+    {"name":"puppetlabs/apt","version_requirement":">= 2.3.0"},
     {"name":"puppetlabs/git","version_requirement":">= 0.4.0"},
     {"name":"puppetlabs/vcsrepo","version_requirement":">=1.0.2"}
   ]


### PR DESCRIPTION
- The apt module upgrade is required to handle obsoleted python-software-properties package (replaced by software-properties-common).
- Will include some other changes that were never released to puppet forge for v0.1.18.